### PR TITLE
Add Python 2.6 compatibility

### DIFF
--- a/pprintpp.py
+++ b/pprintpp.py
@@ -6,7 +6,11 @@ import ast
 import sys
 import warnings
 import unicodedata
-from collections import defaultdict, Counter
+from collections import defaultdict
+try:
+    from collections import Counter
+except ImportError:
+    from backport_collections import Counter
 
 __all__ = [
     "pprint", "pformat", "isreadable", "isrecursive", "saferepr",

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,11 @@ try:
 except IOError:
     long_description = "See https://github.com/wolever/pprintpp"
 
+requires = []
+if sys.version_info < (2, 7):
+    requires.append('backport_collections')
+
+
 setup(
     name="pprintpp",
     version="0.2.1",
@@ -26,7 +31,7 @@ setup(
             'pypprint = pprintpp:console',
         ],
     },
-    install_requires=[],
+    install_requires=requires,
     license="BSD",
     classifiers=[ x.strip() for x in """
         Development Status :: 3 - Alpha

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,pypy
+envlist = py26,py27,py33,pypy
 
 [testenv]
 deps =


### PR DESCRIPTION
This PR enables pprintpp to work under Python 2.6.

The only thing missing was `collections.Counter`. Under 2.6 the implementation from `backport_collections` is used.