### PR TITLE
Add Python 3.6, drop unsupported 2.6, 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
 
 python:
-  - 2.6
   - 2.7
-  - 3.3
-  - 3.4
+  - 3.6
   - 3.5
+  - 3.4
   - pypy
 
 install:
@@ -13,9 +12,3 @@ install:
 
 script:
   - python test.py
-
-matrix:
-  allow_failures:
-    - python: 3.3
-    - python: 3.4
-    - python: 3.5


### PR DESCRIPTION
## Reasons for dropping old ones

* https://en.wikipedia.org/wiki/CPython#Version_history

### 2.6

* https://snarky.ca/stop-using-python-2-6/
* http://www.curiousefficiency.org/posts/2015/04/stop-supporting-python26.html
* http://www.python3statement.org
* Current pip 9 deprecates Python 2.6 support, pip 10 won't support it (https://github.com/pypa/pip/issues/3955)
* Not much PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796

### 3.3

* pip 10 will deprecate Python 3.3 support, pip 11 won't support it (https://github.com/pypa/pip/issues/3796)
* Very little PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796
