### PR TITLE
Replace nose-parameterized with parameterized

### DIFF
--- a/test-requires.txt
+++ b/test-requires.txt
@@ -1,2 +1,2 @@
 nose==1.3.0
-nose_parameterized==0.3.3
+parameterized==0.6.1

--- a/test.py
+++ b/test.py
@@ -5,7 +5,7 @@ import ctypes
 import textwrap
 
 from nose.tools import assert_equal
-from nose_parameterized import parameterized, param
+from parameterized import parameterized, param
 
 sys.path.append("pp/")
 import pp


### PR DESCRIPTION
According to https://pypi.org/project/nose-parameterized nose-parametrized is deprecated in favor of parameterized.

This is necessary to add pprintpp to the nixpkgs package repository because it doesn't contain nose-parameterized.
See NixOS/nixpkgs#53782.