### PR TITLE
Important optimalization for ascii unicode formatting

### DIFF
--- a/pprintpp/__init__.py
+++ b/pprintpp/__init__.py
@@ -62,6 +62,16 @@ def _sorted_py3(iterable):
 
 _sorted = PY3 and _sorted_py3 or _sorted_py3
 
+if hasattr(TextType, 'isascii'):  # Python>=3.7
+    _isascii = TextType.isascii
+else:
+    def _isascii(text):
+        try:
+            text.encode('ascii')
+        except UnicodeEncodeError:
+            return False
+        return True
+
 #
 # End compatibility stuff
 #
@@ -444,6 +454,9 @@ class PrettyPrinter(object):
             return
 
         if r == TextType.__repr__:
+            if _isascii(object):  # Optimalization
+                write(repr(object))
+                return
             if "'" in object and '"' not in object:
                 quote = '"'
                 quotes = {'"': '\\"'}


### PR DESCRIPTION
Time of formatting ascii py3:str/py2:unicode can be optimized.
Below is a prove.

Test script:
```python
from pprintpp import PrettyPrinter
import pprint
import timeit
import sys

PY3 = sys.version_info >= (3, 0, 0)
TextType = str if PY3 else unicode

if hasattr(TextType, 'isascii'):  # Python>=3.7
    _isascii = TextType.isascii
else:
    def _isascii(text):
        try:
            text.encode('ascii')
        except UnicodeEncodeError:
            return False
        return True


class PP(PrettyPrinter):
    def _format(self, object, state):
        if isinstance(object, TextType) and _isascii(object):
            state.write(repr(object))
            return
        super(PP, self)._format(object, state)

s = u'x' * 10000

def pp1():
    PrettyPrinter().pformat(s)

def pp2():
    PP().pformat(s)

def pp3():
    return pprint.pformat(s)


print('Original pprintpp:  %fs' % min(timeit.repeat('pp1()', setup='from __main__ import pp1', number=10)))
print('Optimized pprintpp: %fs' % min(timeit.repeat('pp2()', setup='from __main__ import pp2', number=10)))
print('Standard pprint:    %fs' % min(timeit.repeat('pp3()', setup='from __main__ import pp3', number=10)))
```

Output for Python 3.5:
```
Original pprintpp:  0.203100s
Optimized pprintpp: 0.000554s
Standard pprint:    0.001566s
```

Output for Python 2.7:
```
Original pprintpp:  0.342654s
Optimized pprintpp: 0.001205s
Standard pprint:    0.000415s
```