### PR TITLE
fix: remove "U" move from open(), now universal newline is the default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 os.chdir(os.path.dirname(sys.argv[0]) or ".")
 
 try:
-    long_description = open("README.rst", "U").read()
+    long_description = open("README.rst").read()
 except IOError:
     long_description = "See https://github.com/wolever/pprintpp"
 


### PR DESCRIPTION
In python2.7 you needed to specify `mode='U'` to get universal newline: https://docs.python.org/2.7/library/functions.html#open:~:text=universal%20newlines%20support%3B-,supplying%20%27U%27,-opens%20the%20file

in python3 this is now the default: https://docs.python.org/3/library/functions.html#open:~:text=if%20newline%20is%20None%2C%20universal%20newlines%20mode%20is%20enabled

but if left there, it now triggers an error with 3.11, so let's remove it